### PR TITLE
Refactor/mnms 454

### DIFF
--- a/src/main/java/com/mnms/booking/controller/TicketController.java
+++ b/src/main/java/com/mnms/booking/controller/TicketController.java
@@ -27,14 +27,7 @@ public class TicketController {
     private final TicketService ticketService;
     private final SecurityResponseUtil securityResponseUtil;
 
-    @GetMapping
-    @Operation(summary = "예매한 티켓 정보 조회",
-            description = "예매자가 예매 완료한 전체 티켓 리스트를 조회합니다. (status : 완료, 취소한 티켓 조회 가능)"
-    )
-    public ResponseEntity<SuccessResponse<List<TicketResponseDTO>>> getUserTickets(Authentication authentication) {
-        List<TicketResponseDTO> tickets = ticketService.getTicketsByUser(securityResponseUtil.requireUserId(authentication));
-        return ApiResponseUtil.success(tickets);
-    }
+
 
     @GetMapping("/detail")
     @Operation(summary = "예매한 티켓 정보 디테일 조회",

--- a/src/main/java/com/mnms/booking/controller/TransferController.java
+++ b/src/main/java/com/mnms/booking/controller/TransferController.java
@@ -10,6 +10,7 @@ import com.mnms.booking.dto.response.TransferOthersResponseDTO;
 import com.mnms.booking.exception.global.SuccessResponse;
 import com.mnms.booking.service.OcrParserService;
 import com.mnms.booking.service.OcrService;
+import com.mnms.booking.service.TransferCompletionService;
 import com.mnms.booking.service.TransferService;
 import com.mnms.booking.util.ApiResponseUtil;
 import com.mnms.booking.util.SecurityResponseUtil;
@@ -35,6 +36,7 @@ public class TransferController {
     private final OcrService ocrService;
     private final TransferService transferService;
     private final SecurityResponseUtil securityResponseUtil;
+    private final TransferCompletionService transferCompletionService;
 
 
     ///  가족 인증
@@ -85,7 +87,7 @@ public class TransferController {
     public ResponseEntity<SuccessResponse<Void>> responseTicketFamily(
             @RequestBody UpdateTicketRequestDTO request,
             Authentication authentication) {
-        transferService.updateFamilyTicket(request, securityResponseUtil.requireUserId(authentication));
+        transferCompletionService.updateFamilyTicket(request, securityResponseUtil.requireUserId(authentication));
         return ApiResponseUtil.success(null, "티켓 양도가 성공적으로 진행되었습니다.");
     }
 
@@ -97,7 +99,7 @@ public class TransferController {
     public ResponseEntity<SuccessResponse<TransferOthersResponseDTO>> responseTicketOthers(
             @RequestBody UpdateTicketRequestDTO request,
             Authentication authentication) {
-            TransferOthersResponseDTO response = transferService.proceedOthersTicket(request, securityResponseUtil.requireUserId(authentication));
+            TransferOthersResponseDTO response = transferCompletionService.proceedOthersTicket(request, securityResponseUtil.requireUserId(authentication));
         return ApiResponseUtil.success(response);
     }
 }

--- a/src/main/java/com/mnms/booking/controller/TransferController.java
+++ b/src/main/java/com/mnms/booking/controller/TransferController.java
@@ -18,7 +18,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -31,7 +30,6 @@ import java.util.*;
 @RequestMapping("/api/transfer")
 @RequiredArgsConstructor
 @Tag(name = "양도 API", description = "양도 및 OCR, Ticket 재생성")
-@Slf4j
 public class TransferController {
     private final OcrService ocrService;
     private final TransferService transferService;
@@ -39,10 +37,10 @@ public class TransferController {
     private final TransferCompletionService transferCompletionService;
 
 
-    ///  가족 인증
+    ///  가족관계증명서 인증
     @PostMapping("/extract")
     @Operation(summary = "가족 간 양도 진행 인증 시도",
-            description = "가족관계증명서 pdf를 첨부하고 양도자 및 양수자의 이름과 주민등록번호로 요청하고, 인증 완료 응답을 보냅니다."
+            description = "가족관계증명서 PDF를 첨부하고 양도자 및 양수자의 이름과 주민등록번호로 요청하고, 인증 완료 응답을 보냅니다."
     )
     public ResponseEntity<SuccessResponse<List<PersonInfoResponseDTO>>> extractPersonInfo(
             @RequestPart("file") MultipartFile file,
@@ -94,7 +92,8 @@ public class TransferController {
     /// 지인간 양도 요청 승인
     @PutMapping("/acceptance/others")
     @Operation(summary = "타인 간 양도 요청 완료",
-            description = "타인 간 양도 요청 시, 양수자가 요청을 수락하면 결제 요청이 넘어가게 됩니다."
+            description = "타인 간 양도 요청 시, 양수자가 요청을 수락하면 결제 요청이 넘어가게 됩니다. " +
+            "결제 완료 후 kafka 메시지 받으면 양도 완료됩니다."
     )
     public ResponseEntity<SuccessResponse<TransferOthersResponseDTO>> responseTicketOthers(
             @RequestBody UpdateTicketRequestDTO request,

--- a/src/main/java/com/mnms/booking/dto/request/TicketTransferRequestDTO.java
+++ b/src/main/java/com/mnms/booking/dto/request/TicketTransferRequestDTO.java
@@ -8,6 +8,4 @@ public class TicketTransferRequestDTO {
     private Long recipientId; // 양도받을 가족/지인 ID
     private String transferType; // "FAMILY" 또는 "OTHERS"
     private String senderName;
-    //private String receiveMethod; // 수령 방법 (예: QR, 배송)
-    //private String address;       // 필요시
 }

--- a/src/main/java/com/mnms/booking/dto/request/UpdateTicketRequestDTO.java
+++ b/src/main/java/com/mnms/booking/dto/request/UpdateTicketRequestDTO.java
@@ -1,23 +1,31 @@
 package com.mnms.booking.dto.request;
 
+import com.mnms.booking.dto.response.BookingResponseDTO;
+import com.mnms.booking.dto.response.QrResponseDTO;
+import com.mnms.booking.entity.Ticket;
 import com.mnms.booking.enums.TicketType;
 import com.mnms.booking.enums.TransferStatus;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.stream.Collectors;
+
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateTicketRequestDTO {
     private Long transferId;
     private Long senderId;
-    private String transferStatus;
+    private TransferStatus transferStatus;
 
-    private String deliveryMethod;
+    private TicketType ticketType;
     private String address;
 
-    public TransferStatus getTransferStatusEnum() {
-        return TransferStatus.valueOf(this.transferStatus);
-    }
+//    public TransferStatus getTransferStatusEnum() {
+//        return TransferStatus.valueOf(this.transferStatus);
+//    }
+
 }

--- a/src/main/java/com/mnms/booking/dto/response/TicketDetailResponseDTO.java
+++ b/src/main/java/com/mnms/booking/dto/response/TicketDetailResponseDTO.java
@@ -24,6 +24,7 @@ public class TicketDetailResponseDTO {
     private String posterFile;
 
     // festival
+    private String festivalId; // festivalId
     private String fname; // 공연명
     private String fcltynm; // 장소
 
@@ -39,6 +40,7 @@ public class TicketDetailResponseDTO {
                 .deliveryMethod(ticket.getDeliveryMethod())
                 .address(ticket.getAddress())
                 .qrId(qrIds)
+                .festivalId(festival.getFestivalId())
                 .fname(festival.getFname())
                 .fcltynm(festival.getFcltynm())
                 .posterFile(festival.getPosterFile())

--- a/src/main/java/com/mnms/booking/dto/response/TicketResponseDTO.java
+++ b/src/main/java/com/mnms/booking/dto/response/TicketResponseDTO.java
@@ -27,6 +27,7 @@ public class TicketResponseDTO {
     private ReservationStatus reservationStatus; // 예매상태
 
     // festival
+    private String festivalId; // festivalId
     private String fname; // 공연명
     private String fcltynm; // 장소
 
@@ -39,6 +40,7 @@ public class TicketResponseDTO {
                 .deliveryMethod(ticket.getDeliveryMethod())
                 .reservationDate(ticket.getReservationDate())
                 .reservationStatus(ticket.getReservationStatus())
+                .festivalId(festival.getFestivalId())
                 .fname(festival.getFname())
                 .fcltynm(festival.getFcltynm())
                 .build();

--- a/src/main/java/com/mnms/booking/dto/response/TicketTransferResponseDTO.java
+++ b/src/main/java/com/mnms/booking/dto/response/TicketTransferResponseDTO.java
@@ -20,7 +20,7 @@ public class TicketTransferResponseDTO {
     ///  TRANSFER
     private Long senderId;
     private String senderName;
-    private TransferType type;
+    private TransferType transferType;
     private LocalDateTime createdAt;
     private String status;
 
@@ -32,13 +32,14 @@ public class TicketTransferResponseDTO {
 
     ///  TICKET
     private LocalDateTime performanceDate;
+    private String reservationNumber;
     private int selectedTicketCount;
 
     public static TicketTransferResponseDTO from(Transfer transfer, Ticket ticket, Festival festival) {
         return TicketTransferResponseDTO.builder()
                 .senderId(transfer.getSenderId())
                 .senderName(transfer.getSenderName())
-                .type(transfer.getType())
+                .transferType(transfer.getTransferType())
                 .createdAt(transfer.getCreatedAt())
                 .status(String.valueOf(transfer.getStatus()))
                 .fname(festival.getFname())
@@ -46,6 +47,7 @@ public class TicketTransferResponseDTO {
                 .fcltynm(festival.getFcltynm())
                 .ticketPrice(festival.getTicketPrice())
                 .performanceDate(ticket.getPerformanceDate())
+                .reservationNumber(ticket.getReservationNumber())
                 .selectedTicketCount(ticket.getSelectedTicketCount())
                 .build();
     }

--- a/src/main/java/com/mnms/booking/dto/response/TransferOthersResponseDTO.java
+++ b/src/main/java/com/mnms/booking/dto/response/TransferOthersResponseDTO.java
@@ -1,5 +1,8 @@
 package com.mnms.booking.dto.response;
 
+import com.mnms.booking.entity.Festival;
+import com.mnms.booking.entity.Ticket;
+import com.mnms.booking.entity.Transfer;
 import lombok.Builder;
 import lombok.Data;
 
@@ -21,4 +24,17 @@ public class TransferOthersResponseDTO {
     private int ticketPrice;
     private String fname;
     private String posterFile;
+
+    public static TransferOthersResponseDTO from(Transfer transfer, Ticket ticket, Festival festival, Long userId) {
+        return TransferOthersResponseDTO.builder()
+                .reservationNumber(ticket.getReservationNumber())
+                .senderId(transfer.getSenderId())
+                .receiverId(userId)
+                .selectedTicketCount(ticket.getSelectedTicketCount())
+                .ticketPrice(festival.getTicketPrice())
+                .fname(festival.getFname())
+                .posterFile(festival.getPosterFile())
+                .performanceDate(ticket.getPerformanceDate())
+                .build();
+    }
 }

--- a/src/main/java/com/mnms/booking/dto/response/TransferOthersResponseDTO.java
+++ b/src/main/java/com/mnms/booking/dto/response/TransferOthersResponseDTO.java
@@ -37,4 +37,13 @@ public class TransferOthersResponseDTO {
                 .performanceDate(ticket.getPerformanceDate())
                 .build();
     }
+
+    // 취소
+    public static TransferOthersResponseDTO canceled(String reservationNumber, Long senderId, Long receiverId) {
+        return TransferOthersResponseDTO.builder()
+                .reservationNumber(reservationNumber)
+                .senderId(senderId)
+                .receiverId(receiverId)
+                .build();
+    }
 }

--- a/src/main/java/com/mnms/booking/dto/response/TransferStatusResponseDTO.java
+++ b/src/main/java/com/mnms/booking/dto/response/TransferStatusResponseDTO.java
@@ -1,0 +1,5 @@
+package com.mnms.booking.dto.response;
+
+import com.mnms.booking.enums.TransferStatus;
+
+public record TransferStatusResponseDTO(String reservationNumber, TransferStatus status) {}

--- a/src/main/java/com/mnms/booking/entity/Transfer.java
+++ b/src/main/java/com/mnms/booking/entity/Transfer.java
@@ -1,5 +1,6 @@
 package com.mnms.booking.entity;
 
+import com.mnms.booking.enums.TicketType;
 import com.mnms.booking.enums.TransferStatus;
 import com.mnms.booking.enums.TransferType;
 import jakarta.persistence.*;
@@ -31,10 +32,15 @@ public class Transfer {
     private TransferType type;
 
     @Setter
+    private TicketType ticketType;
+
+    @Setter
+    private String address;
+
+    @Setter
     @Builder.Default
     private TransferStatus status = TransferStatus.REQUESTED;
 
     @Builder.Default
     private LocalDateTime createdAt = LocalDateTime.now();
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/mnms/booking/entity/Transfer.java
+++ b/src/main/java/com/mnms/booking/entity/Transfer.java
@@ -29,7 +29,7 @@ public class Transfer {
     @JoinColumn(name = "ticket_id", nullable = false)
     private Ticket ticket;
 
-    private TransferType type;
+    private TransferType transferType;
 
     @Setter
     private TicketType ticketType;

--- a/src/main/java/com/mnms/booking/enums/TicketType.java
+++ b/src/main/java/com/mnms/booking/enums/TicketType.java
@@ -1,6 +1,6 @@
 package com.mnms.booking.enums;
 
-public enum TicketType {
+public enum  TicketType {
     MOBILE,
     PAPER
 }

--- a/src/main/java/com/mnms/booking/exception/ErrorCode.java
+++ b/src/main/java/com/mnms/booking/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     TRANSFER_NOT_MATCH_RECEIVER("TR005", "양도 승인하는 양수자가 맞지 않습니다.", HttpStatus.BAD_REQUEST),
     TRANSFER_NOT_MATCH_TYPE("TR006", "양도 타입이 맞지 않습니다.", HttpStatus.BAD_REQUEST),
     TRANSFER_NOT_MATCH_SENDER("TR007", "양도자의 티켓과 매칭되지 않습니다.", HttpStatus.CONFLICT),
+    TRANSFER_ALREADY_EXIST_REQUEST("T008", "이미 진행되고 있는 양도 거래가 존재합니다.", HttpStatus.CONFLICT),
 
     // STATISTICS (통계 관련 에러 코드 추가)
     STATISTICS_ACCESS_DENIED("ST001", "통계 정보에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/mnms/booking/exception/ErrorCode.java
+++ b/src/main/java/com/mnms/booking/exception/ErrorCode.java
@@ -50,7 +50,7 @@ public enum ErrorCode {
     TRANSFER_NOT_EXIST("TR004", "양도 요청이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     TRANSFER_NOT_MATCH_RECEIVER("TR005", "양도 승인하는 양수자가 맞지 않습니다.", HttpStatus.BAD_REQUEST),
     TRANSFER_NOT_MATCH_TYPE("TR006", "양도 타입이 맞지 않습니다.", HttpStatus.BAD_REQUEST),
-    TRANSFER_NOT_MATCH_SENDER("TR007", "양도자의 티켓과 매칭되지 않습니다.", HttpStatus.CONFLICT);
+    TRANSFER_NOT_MATCH_SENDER("TR007", "양도자의 티켓과 매칭되지 않습니다.", HttpStatus.CONFLICT),
 
     // STATISTICS (통계 관련 에러 코드 추가)
     STATISTICS_ACCESS_DENIED("ST001", "통계 정보에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/mnms/booking/exception/ErrorCode.java
+++ b/src/main/java/com/mnms/booking/exception/ErrorCode.java
@@ -51,7 +51,7 @@ public enum ErrorCode {
     TRANSFER_NOT_MATCH_RECEIVER("TR005", "양도 승인하는 양수자가 맞지 않습니다.", HttpStatus.BAD_REQUEST),
     TRANSFER_NOT_MATCH_TYPE("TR006", "양도 타입이 맞지 않습니다.", HttpStatus.BAD_REQUEST),
     TRANSFER_NOT_MATCH_SENDER("TR007", "양도자의 티켓과 매칭되지 않습니다.", HttpStatus.CONFLICT),
-    TRANSFER_ALREADY_EXIST_REQUEST("T008", "이미 진행되고 있는 양도 거래가 존재합니다.", HttpStatus.CONFLICT),
+    TRANSFER_ALREADY_EXIST_REQUEST("T008", "진행되고 있는 양도 거래가 존재하거나, 양도 1회 진행한 티켓입니다. 양도는 1회로 제한됩니다.", HttpStatus.CONFLICT),
 
     // STATISTICS (통계 관련 에러 코드 추가)
     STATISTICS_ACCESS_DENIED("ST001", "통계 정보에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/mnms/booking/kafka/listener/PaymentListener.java
+++ b/src/main/java/com/mnms/booking/kafka/listener/PaymentListener.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mnms.booking.kafka.dto.PaymentSuccessEventDTO;
 import com.mnms.booking.service.BookingCommandService;
+import com.mnms.booking.service.TransferCompletionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class PaymentListener {
 
     private final BookingCommandService bookingCommandService;
+    private final TransferCompletionService transferCompletionService;
 
     @KafkaListener(topics = "${app.kafka.topic.payment-event}", groupId = "booking-service-group")
     public void consumePaymentSuccess(String message) throws JsonProcessingException {
@@ -38,5 +40,16 @@ public class PaymentListener {
 
         PaymentSuccessEventDTO event = objectMapper.readValue(message, PaymentSuccessEventDTO.class);
         bookingCommandService.cancelBooking(event.getReservationNumber(), event.isSuccess());
+    }
+
+    @KafkaListener(topics = "${app.kafka.topic.transfer-payment-event}", groupId = "booking-service-group")
+    public void consumeTransferSuccess(String message) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        PaymentSuccessEventDTO event = objectMapper.readValue(message, PaymentSuccessEventDTO.class);
+        transferCompletionService.updateOthersTicket(event.getReservationNumber(), event.isSuccess());
     }
 }

--- a/src/main/java/com/mnms/booking/repository/TransferRepository.java
+++ b/src/main/java/com/mnms/booking/repository/TransferRepository.java
@@ -3,6 +3,7 @@ package com.mnms.booking.repository;
 import com.mnms.booking.entity.Ticket;
 import com.mnms.booking.entity.Transfer;
 import com.mnms.booking.enums.TransferStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,8 +13,11 @@ import java.util.Optional;
 
 public interface TransferRepository extends JpaRepository<Transfer, Long> {
     Transfer findByTicket(Ticket ticket);
+
+    @EntityGraph(attributePaths = {"ticket", "ticket.qrCodes"})
     Optional<Transfer> findById(Long id);
-    boolean existsByTicket(Ticket ticket);
+
+    boolean existsByTicket_Id(Long id);
 
     @Query("SELECT t FROM Transfer t " +
             "JOIN FETCH t.ticket ticket " +

--- a/src/main/java/com/mnms/booking/repository/TransferRepository.java
+++ b/src/main/java/com/mnms/booking/repository/TransferRepository.java
@@ -2,13 +2,25 @@ package com.mnms.booking.repository;
 
 import com.mnms.booking.entity.Ticket;
 import com.mnms.booking.entity.Transfer;
+import com.mnms.booking.enums.TransferStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface TransferRepository extends JpaRepository<Transfer, Long> {
     Transfer findByTicket(Ticket ticket);
-    List<Transfer> findByReceiverId(Long userId);
     Optional<Transfer> findById(Long id);
+    boolean existsByTicket(Ticket ticket);
+
+    @Query("SELECT t FROM Transfer t " +
+            "JOIN FETCH t.ticket ticket " +
+            "JOIN FETCH ticket.festival " +
+            "WHERE t.receiverId = :receiverId " +
+            "AND t.status NOT IN :excludedStatuses")
+    List<Transfer> findByReceiverIdWithTicketAndFestival(
+            @Param("receiverId") Long receiverId,
+            @Param("excludedStatuses") List<TransferStatus> excludedStatuses);
 }

--- a/src/main/java/com/mnms/booking/repository/TransferRepository.java
+++ b/src/main/java/com/mnms/booking/repository/TransferRepository.java
@@ -1,5 +1,6 @@
 package com.mnms.booking.repository;
 
+import com.mnms.booking.entity.Ticket;
 import com.mnms.booking.entity.Transfer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TransferRepository extends JpaRepository<Transfer, Long> {
+    Transfer findByTicket(Ticket ticket);
     List<Transfer> findByReceiverId(Long userId);
     Optional<Transfer> findById(Long id);
 }

--- a/src/main/java/com/mnms/booking/service/OcrParserService.java
+++ b/src/main/java/com/mnms/booking/service/OcrParserService.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/com/mnms/booking/service/OcrParserService.java
+++ b/src/main/java/com/mnms/booking/service/OcrParserService.java
@@ -47,12 +47,14 @@ public class OcrParserService {
     private static PersonInfoResponseDTO matchPersonInfo(
             String name, String rrn, List<String> ocrTexts) {
 
-        String normalizedNamePattern = "\\b" + Pattern.quote(name.replaceAll("\\s", "")) + "\\b";
+        // 임시 수정
+        String normalizedNamePattern = name.replaceAll("\\s", "").replaceAll("\\\\[bQE]", "");
+        log.info("normalizedNamePattern : {}", normalizedNamePattern);
 
         String matchedName = ocrTexts.stream()
                 .map(t -> t.replaceAll("\\([^)]*\\)", "")
                         .replaceAll("[\\s\\(\\)\\[\\]{}]", ""))
-                .filter(t -> t.matches(".*" + normalizedNamePattern + ".*"))
+                .filter(t -> t.contains(normalizedNamePattern))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRANSFER_NOT_FOUND_NAME));
 
@@ -61,9 +63,10 @@ public class OcrParserService {
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRANSFER_NOT_FOUND_RRN));
 
+        /* 임시 삭제
         if (!name.equals(matchedName)) {
             throw new BusinessException(ErrorCode.TRANSFER_NOT_FOUND_NAME);
-        }
+        }*/
 
         return new PersonInfoResponseDTO(matchedName, matchedRrn);
     }

--- a/src/main/java/com/mnms/booking/service/OcrService.java
+++ b/src/main/java/com/mnms/booking/service/OcrService.java
@@ -52,9 +52,7 @@ public class OcrService {
             // 5. 헤더 구성
             HttpHeaders headers = getApiHeaders();
 
-
-            String response = postApi(headers, multipartBody);
-            return response;
+            return postApi(headers, multipartBody);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -62,13 +60,12 @@ public class OcrService {
 
     private String postApi(HttpHeaders headers, MultiValueMap<String, Object> multipartBody) {
         RestClient restClient=RestClient.create();
-        String response = restClient.post()
+        return restClient.post()
                 .uri(ocrInvokeUrl)
                 .headers(h -> h.addAll(headers))
                 .body(multipartBody)
                 .retrieve()
                 .body(String.class);
-        return response;
     }
 
     private HttpHeaders getApiHeaders() {

--- a/src/main/java/com/mnms/booking/service/TransferCompletionService.java
+++ b/src/main/java/com/mnms/booking/service/TransferCompletionService.java
@@ -104,8 +104,9 @@ public class TransferCompletionService {
     public void updateOthersTicket(String reservationNumber, boolean paymentStatus) {
         Ticket ticket = ticketRepository.findByReservationNumber(reservationNumber)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TICKET_NOT_FOUND));
-
         Transfer transfer = transferRepository.findByTicket(ticket);
+
+        // 결제 kafka 로직 변경 시 수정 예정
         if (!paymentStatus) {
             transfer.setStatus(TransferStatus.CANCELED);
             return;

--- a/src/main/java/com/mnms/booking/service/TransferCompletionService.java
+++ b/src/main/java/com/mnms/booking/service/TransferCompletionService.java
@@ -3,6 +3,7 @@ package com.mnms.booking.service;
 import com.mnms.booking.dto.request.UpdateTicketRequestDTO;
 import com.mnms.booking.dto.response.TicketStatusResponseDTO;
 import com.mnms.booking.dto.response.TransferOthersResponseDTO;
+import com.mnms.booking.dto.response.TransferStatusResponseDTO;
 import com.mnms.booking.entity.Festival;
 import com.mnms.booking.entity.QrCode;
 import com.mnms.booking.entity.Ticket;
@@ -96,9 +97,9 @@ public class TransferCompletionService {
 
         Transfer transfer = transferRepository.findByTicket(ticket);
 
-        ReservationStatus newStatus = paymentStatus ?
-                ReservationStatus.CONFIRMED :
-                ReservationStatus.CANCELED;
+        TransferStatus newStatus = paymentStatus ?
+                TransferStatus.COMPLETED :
+                TransferStatus.APPROVED;
 
         // 결제 kafka 로직 변경 시 수정 예정
         if (paymentStatus) {
@@ -111,13 +112,11 @@ public class TransferCompletionService {
                     .address(transfer.getAddress())
                     .build();
             applyTicketAndQrUpdate(transfer, request, transfer.getReceiverId(), false);
-        } else{
-            transfer.setStatus(TransferStatus.CANCELED);
         }
         // websocket 전송
         messagingTemplate.convertAndSend(
                 "/topic/transfer/" + transfer.getReceiverId(),
-                new TicketStatusResponseDTO(ticket.getReservationNumber(), newStatus));
+                new TransferStatusResponseDTO(ticket.getReservationNumber(), newStatus));
     }
 
     /// UTIL

--- a/src/main/java/com/mnms/booking/service/TransferService.java
+++ b/src/main/java/com/mnms/booking/service/TransferService.java
@@ -33,7 +33,7 @@ public class TransferService {
         Ticket ticket = ticketRepository.findByReservationNumber(dto.getReservationNumber())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TICKET_NOT_FOUND));
 
-        if(transferRepository.existsByTicket(ticket)){
+        if(transferRepository.existsByTicket_Id(ticket.getId())){
             throw new BusinessException(ErrorCode.TRANSFER_ALREADY_EXIST_REQUEST);
         }
 
@@ -46,7 +46,7 @@ public class TransferService {
                 .senderId(userId)
                 .senderName(dto.getSenderName())
                 .receiverId(dto.getRecipientId())
-                .type("OTHERS".equals(dto.getTransferType()) ? TransferType.OTHERS : TransferType.FAMILY)
+                .transferType("OTHERS".equals(dto.getTransferType()) ? TransferType.OTHERS : TransferType.FAMILY)
                 .status(TransferStatus.REQUESTED)
                 .build();
         transferRepository.save(transfer);

--- a/src/main/java/com/mnms/booking/service/TransferService.java
+++ b/src/main/java/com/mnms/booking/service/TransferService.java
@@ -1,30 +1,21 @@
 package com.mnms.booking.service;
 
 import com.mnms.booking.dto.request.TicketTransferRequestDTO;
-import com.mnms.booking.dto.request.UpdateTicketRequestDTO;
 import com.mnms.booking.dto.response.TicketTransferResponseDTO;
-import com.mnms.booking.dto.response.TransferOthersResponseDTO;
 import com.mnms.booking.entity.Festival;
-import com.mnms.booking.entity.QrCode;
 import com.mnms.booking.entity.Ticket;
 import com.mnms.booking.entity.Transfer;
-import com.mnms.booking.enums.TicketType;
 import com.mnms.booking.enums.TransferStatus;
 import com.mnms.booking.enums.TransferType;
 import com.mnms.booking.exception.BusinessException;
 import com.mnms.booking.exception.ErrorCode;
-import com.mnms.booking.repository.QrCodeRepository;
 import com.mnms.booking.repository.TicketRepository;
 import com.mnms.booking.repository.TransferRepository;
-import com.mnms.booking.util.CommonUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.expression.ExpressionException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -34,11 +25,7 @@ import java.util.List;
 public class TransferService {
 
     private final TicketRepository ticketRepository;
-    private final QrCodeRepository qrCodeRepository;
     private final TransferRepository transferRepository;
-    private final CommonUtils commonUtils;
-    private final QrCodeService qrCodeService;
-
 
     ///  양도 요청
     @Transactional
@@ -58,7 +45,6 @@ public class TransferService {
                 .type("OTHERS".equals(dto.getTransferType()) ? TransferType.OTHERS : TransferType.FAMILY)
                 .status(TransferStatus.REQUESTED)
                 .build();
-
         transferRepository.save(transfer);
     }
 
@@ -81,158 +67,5 @@ public class TransferService {
                     return TicketTransferResponseDTO.from(transfer, ticket, festival);
                 })
                 .toList();
-    }
-
-
-    ///  양도 수락
-    /// 가족 간 양도 수락
-    @Transactional
-    public void updateFamilyTicket(UpdateTicketRequestDTO request, Long userId) {
-        Transfer transfer = getTransferOrThrow(request.getTransferId());
-
-        validateSenderId(request.getSenderId(), transfer.getTicket().getUserId());
-
-        if(!transfer.getType().equals(TransferType.FAMILY)){
-            throw new BusinessException(ErrorCode.TRANSFER_NOT_MATCH_TYPE);
-        }
-        validateReceiver(transfer, userId);
-
-        // CANCELED 처리
-        if (request.getTransferStatusEnum() == TransferStatus.CANCELED) {
-            transfer.setStatus(TransferStatus.CANCELED);
-            return;
-        }
-
-        // ticket 점검
-        Ticket ticket = getTicketOrThrow(transfer.getTicket().getReservationNumber());
-        validateTicketStatus(ticket);
-
-        // transfer 상태 업데이트
-        transfer.setStatus(TransferStatus.COMPLETED);
-
-        // ticket 정보 업데이트
-        updateTicketInfo(ticket, request, userId);
-
-        // QR 코드 업데이트
-        updateQrCodes(ticket, request, userId);
-    }
-
-    /// 지인 간 양도 요청 수락
-    @Transactional
-    public TransferOthersResponseDTO proceedOthersTicket(UpdateTicketRequestDTO request, Long userId) {
-
-        Transfer transfer = getTransferOrThrow(request.getTransferId());
-        validateSenderId(request.getSenderId(), transfer.getTicket().getUserId());
-
-        if(!transfer.getType().equals(TransferType.OTHERS)){
-            throw new BusinessException(ErrorCode.TRANSFER_NOT_MATCH_TYPE);
-        }
-
-        String reservationNumber = transfer.getTicket().getReservationNumber();
-        validateReceiver(transfer, userId);
-
-        // CANCELED 처리
-        if (request.getTransferStatusEnum() == TransferStatus.CANCELED) {
-            transfer.setStatus(TransferStatus.CANCELED);
-            return TransferOthersResponseDTO.builder()
-                    .reservationNumber(reservationNumber)
-                    .senderId(transfer.getSenderId())
-                    .receiverId(userId)
-                    .build();
-        }
-
-        Ticket ticket = getTicketOrThrow(reservationNumber);
-        validateTicketStatus(ticket);
-        Festival festival = ticket.getFestival();
-
-        // transfer 업데이트
-        transfer.setStatus(TransferStatus.APPROVED);
-
-        return TransferOthersResponseDTO.builder()
-                .reservationNumber(ticket.getReservationNumber())
-                .senderId(transfer.getSenderId())
-                .receiverId(userId)
-                .selectedTicketCount(ticket.getSelectedTicketCount())
-                .ticketPrice(festival.getTicketPrice())
-                .fname(festival.getFname())
-                .posterFile(festival.getPosterFile())
-                .performanceDate(ticket.getPerformanceDate())
-                .build();
-    }
-
-
-    /// 결제 KAFKA 구독 메시지 받고 결제 완료 수행
-    @Transactional
-    public void updateOthersTicket(UpdateTicketRequestDTO request, Long receiverId) {
-        Transfer transfer = getTransferOrThrow(request.getTransferId());
-
-        Ticket ticket = getTicketOrThrow(transfer.getTicket().getReservationNumber());
-        validateTicketStatus(ticket);
-
-        transfer.setStatus(TransferStatus.COMPLETED);
-
-        updateTicketInfo(ticket, request, receiverId);
-        updateQrCodes(ticket, request, receiverId);
-    }
-
-
-    /// UTIL
-    private void validateSenderId(Long senderId, Long ticketUserId) {
-        if (!senderId.equals(ticketUserId)) {
-            throw new BusinessException(ErrorCode.TRANSFER_NOT_MATCH_SENDER);
-        }
-    }
-
-    private void validateReceiver(Transfer transfer, Long userId){
-        // 양수자 확인
-        if (!userId.equals(transfer.getReceiverId())){
-            throw new BusinessException(ErrorCode.TRANSFER_NOT_MATCH_RECEIVER);
-        }
-    }
-    private Transfer getTransferOrThrow(Long transferId) {
-        return transferRepository.findById(transferId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TRANSFER_NOT_EXIST));
-    }
-
-    private Ticket getTicketOrThrow(String reservationNumber) {
-        return ticketRepository.findByReservationNumber(reservationNumber)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TICKET_NOT_FOUND));
-    }
-
-    private void validateTicketStatus(Ticket ticket) {
-        if (ticket.isExpired()) {
-            throw new BusinessException(ErrorCode.TICKET_EXPIRED);
-        }
-        if (ticket.isCanceled()) {
-            throw new BusinessException(ErrorCode.TICKET_CANCELED);
-        }
-    }
-
-    /// ticket 정보 업데이트
-    private void updateTicketInfo(Ticket ticket, UpdateTicketRequestDTO request, Long receiverId) {
-        TicketType deliveryMethod = TicketType.valueOf(request.getDeliveryMethod());
-
-        ticket.updateTicketInfo(
-                commonUtils.generateReservationNumber(),
-                deliveryMethod,
-                receiverId,
-                LocalDate.now(),
-                request.getAddress()
-        );
-    }
-
-    /// qr 정보 업데이트
-    private void updateQrCodes(Ticket ticket, UpdateTicketRequestDTO request,  Long receiverId) {
-        List<QrCode> existingQrs = qrCodeRepository.findByTicketId(ticket.getId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.QR_CODE_NOT_FOUND));
-
-        existingQrs.forEach(qr -> {
-            qr.setQrCodeId(qrCodeService.generateQrCodeId());
-            qr.setUserId(receiverId);
-            qr.setTicket(ticket);
-        });
-
-        ticket.getQrCodes().clear();
-        ticket.getQrCodes().addAll(existingQrs);
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -28,7 +28,7 @@ spring.data.redis.port=${REDIS_PORT}
 app.kafka.topic.festival-event=festival-topic
 app.kafka.topic.payment-event= payment-status-events
 app.kafka.topic.payment-cancel-event=payment-cancel-events
-app.kafka.topic.transfer-payment-event=payment-transfer-events
+app.kafka.topic.transfer-payment-event=payment-transfer-status-events
 
 spring.kafka.bootstrap-servers=${KAFKA_SERVERS}
 spring.kafka.consumer.auto-offset-reset=earliest

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -28,6 +28,7 @@ spring.data.redis.port=${REDIS_PORT}
 app.kafka.topic.festival-event=festival-topic
 app.kafka.topic.payment-event= payment-status-events
 app.kafka.topic.payment-cancel-event=payment-cancel-events
+app.kafka.topic.transfer-payment-event=payment-transfer-events
 
 spring.kafka.bootstrap-servers=${KAFKA_SERVERS}
 spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
양도 수정 1차 완료

결제(backend) -> 결제 수행 후 kafka topic 메시지 발행 
-> booking(back) kafka 구독
-> websocket으로 front에게 결제 완료/실패 전달

*참고
kafka 구독 반환값 추후 reservationNumber 말고 다른 걸 넘길 수 있음
버그 : ocr 3차 추출에서 이름 조건 다소 느슨해짐. 추후 수정 필요